### PR TITLE
Warehouse made bigger, multiple production lines made

### DIFF
--- a/AGILE_STEM_GAME/Assets/Imported Assets/Factory Assets 1/Classroom/Wider Building.prefab
+++ b/AGILE_STEM_GAME/Assets/Imported Assets/Factory Assets 1/Classroom/Wider Building.prefab
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5fed97070c2d56506d28de7a4a80c5e3ae10d5569639a781ea8f1cab93b1b496
+size 116284

--- a/AGILE_STEM_GAME/Assets/Imported Assets/Factory Assets 1/Classroom/Wider Building.prefab.meta
+++ b/AGILE_STEM_GAME/Assets/Imported Assets/Factory Assets 1/Classroom/Wider Building.prefab.meta
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:962b9f32444df5db5183089df3f7bd5199cd3589f3cf4188ad856070f387449f
+size 154

--- a/AGILE_STEM_GAME/Assets/Prefabs/RotatingSign.prefab
+++ b/AGILE_STEM_GAME/Assets/Prefabs/RotatingSign.prefab
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:294ccaa1b8cefcc856d64c0b9703fc3922285f221228e45f3d748a8e857bde8f
+oid sha256:11273e1314fe928d2c59cfea628bbeccd4cc9545f51eaad2f2712c49a057aba8
 size 22128

--- a/AGILE_STEM_GAME/Assets/Scenes/MultipleFactoryLines.unity
+++ b/AGILE_STEM_GAME/Assets/Scenes/MultipleFactoryLines.unity
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2a654424448c4d8e06f3a4b8eda7b7d6f72be5bf0b4471891a60c7f826ecb952
+size 249928

--- a/AGILE_STEM_GAME/Assets/Scenes/MultipleFactoryLines.unity.meta
+++ b/AGILE_STEM_GAME/Assets/Scenes/MultipleFactoryLines.unity.meta
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:257613ae5247d1d63d461d55867b2ba2c3e2cfb3be3f836d6ad3f5c6c1042d2a
+size 155


### PR DESCRIPTION
The warehouse was made wider to accommodate the three production lines, to add bottles to this will require pathing for forklifts to go to each funnel.